### PR TITLE
Fix index sorting bug

### DIFF
--- a/snmp_passpersist.py
+++ b/snmp_passpersist.py
@@ -211,7 +211,7 @@ class PassPersist:
 		self.pending=dict()
 
 		# Generate index 
-		self.data_idx = sorted(self.data.keys())
+		self.data_idx = sorted(self.data.keys(), key=lambda k: tuple(int(part) for part in k.split('.')))
 
 	def main_update(self):
 		"""


### PR DESCRIPTION
Hello Nagius,

I fixed index sorting to use numerical sorting instead of text sorting.

So instead of ordering this way:
.1.10
.1.8
.1.9

It will order like this:
.1.8
.1.9
.1.10

Rayed
