### PR TITLE
allow testing the code on windows

### DIFF
--- a/snmp_passpersist.py
+++ b/snmp_passpersist.py
@@ -284,7 +284,10 @@ class PassPersist:
 		Direct call is unnecessary.
 		"""
 		# Renice updater thread to limit overload
-		os.nice(1)
+		try:
+			os.nice(1)
+		except AttributeError as er:
+			pass # os.nice is not available on windows
 		time.sleep(self.refresh)
 
 		try:


### PR DESCRIPTION
os.nice(1) doesn't work on windows, ignoring the error allows writing code on windows, test it with DUMPALL and then deploy it on linux when completed. 