### PR TITLE
Add a small method to allow for adding OIDs

### DIFF
--- a/snmp_passpersist.py
+++ b/snmp_passpersist.py
@@ -193,6 +193,10 @@ class PassPersist:
 		"""General function to add an oid entry to the MIB subtree."""
 		self.pending[oid]={'type': str(type), 'value': str(value)}
 
+	def add_oid(self,oid,value):
+		"""Short helper to add an object ID to the MIB subtree."""
+		self.add_oid_entry(oid,'OBJECTID',value)
+
 	def add_int(self,oid,value):
 		"""Short helper to add an integer value to the MIB subtree."""
 		self.add_oid_entry(oid,'INTEGER',value)


### PR DESCRIPTION
This patch allows you to add a simple OID string and
give it the proper type.  For example, calling this
method with

      pp.add_oid('.1.3.6.1.2.1.47','1.1.1.1.3.1','0.0')

where "0.0" represents SNMPv2-SMI::zeroDotZero.

This results in the following response when we walk this OID:

ENTITY-MIB::entPhysicalVendorType.1 = OID: SNMPv2-SMI::zeroDotZero