### PR TITLE
handle Python3's AttributeError and EOFError

### DIFF
--- a/snmp_passpersist.py
+++ b/snmp_passpersist.py
@@ -247,9 +247,10 @@ class PassPersist(object):
 		the start method.
 		Direct call is unnecessary.
 		"""
-		line = sys.stdin.readline().strip()
+		line = sys.stdin.readline()
 		if not line:
 			raise EOFError()
+		line = line.strip()
 
 		if 'PING' in line:
 			print("PONG")
@@ -402,8 +403,13 @@ class PassPersist(object):
 		while up.isAlive(): # Do not serve data if the Updater thread has died
 			try:
 				self.main_passpersist()
+			except EOFError:
+				break
 			except:
-				up._Thread__stop()
+				try:
+					up._Thread__stop()
+				except AttributeError: # python3 has not Thread._Thread__stop
+					pass
 				raise
 
 # vim: ts=4:sw=4:ai


### PR DESCRIPTION
Current implementation raises EOFError on EOF and on empty line too and doesn't respects, that the Python3 has not Thread._Thread__stop() method.

This PR moves the strip of input line after empty line check, to raise EOFError only for EOFs and leave empty line as "unknown" input. A t end it adds handling for EOFError, to silently close while loop, because it is internal exception, which is not needed to reraise.

The up._Thread__stop() calling is Python2 only, then i add exception handling, to silently ignore AttributeError on Python3.