### PR TITLE
remove invalid non-ASCII character c2

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This module is a SNMP passpersist backend for Net-SNMP.
 
-The `snmp_passpersist.PassPersist` class present a convenient way to creare a MIB subtree and expose it to snmp via it's passpersist protocol.
+The `snmp_passpersist.PassPersist` class present a convenient way to creare a MIB subtree and expose it to snmp via its passpersist protocol.
 Two threads are used, one for talking with snmpd and a second that trigger the update process at a fixed interval.
 
 The keyword 'DUMP' has been added to the protocol for testing purpose.
@@ -10,12 +10,12 @@ The keyword 'DUMP' has been added to the protocol for testing purpose.
 
 ## Installation
 
-The easiest way is using pip : 
+The easiest way is using pip :
 ```
 pip install snmp_passpersist
 ```
 
-If you're running Python 2.x and see this error : 
+If you're running Python 2.x and see this error :
 ```
 Traceback (most recent call last):
   File "test.py", line 3, in <module>


### PR DESCRIPTION
Resolves an error encountered in unattended install in Kickstart environment:

```
Collecting https://github.com/nagius/snmp_passpersist/archive/master.zip
  Downloading https://github.com/nagius/snmp_passpersist/archive/master.zip
    ERROR: Command errored out with exit status 1:
     command: /usr/bin/python3.4 -c 'import sys, setuptools, tokenize; sys.argv[0] = '"'"'/tmp/pip-req-build-xtslicbi/setup.py'"'"'; __file__='"'"'/tmp/pip-req-build-xtslicbi/setup.py'"'"';f=getattr(tokenize, '"'"'open'"'"', open)(__file__);code=f.read().replace('"'"'\r\n'"'"', '"'"'\n'"'"');f.close();exec(compile(code, __file__, '"'"'exec'"'"'))' egg_info --egg-base pip-egg-info
         cwd: /tmp/pip-req-build-xtslicbi/
    Complete output (9 lines):
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/tmp/pip-req-build-xtslicbi/setup.py", line 15, in <module>
        long_description=read('README.md'),
      File "/tmp/pip-req-build-xtslicbi/setup.py", line 8, in read
        return open(os.path.join(os.path.dirname(__file__), fname)).read()
      File "/usr/lib64/python3.4/encodings/ascii.py", line 26, in decode
        return codecs.ascii_decode(input, self.errors)[0]
    UnicodeDecodeError: 'ascii' codec can't decode byte 0xc2 in position 456: ordinal not in range(128)
    ----------------------------------------
ERROR: Command errored out with exit status 1: python setup.py egg_info Check the logs for full command output.
```
