### PR TITLE
Use Thread.is_alive() instead of deprecated Thread.isAlive()

### DIFF
--- a/snmp_passpersist.py
+++ b/snmp_passpersist.py
@@ -400,7 +400,7 @@ class PassPersist(object):
 		up.start()
 
 		# Main loop
-		while up.isAlive(): # Do not serve data if the Updater thread has died
+		while up.is_alive(): # Do not serve data if the Updater thread has died
 			try:
 				self.main_passpersist()
 			except EOFError:


### PR DESCRIPTION
Apparently Thread.isAlive() was deprecated awhile back and finally removed in Python 3.9.  It seems that Thread.is_alive() is the the correct replacement.  I have not done any regression testing with earlier versions of Python, so buyer beware....