### PR TITLE
makes snmp_passpersist ignore empty input lines

### DIFF
--- a/snmp_passpersist.py
+++ b/snmp_passpersist.py
@@ -243,10 +243,12 @@ class PassPersist(object):
 		the start method.
 		Direct call is unnecessary.
 		"""
-		line = sys.stdin.readline()
-		if not line:
-			raise EOFError()
-		line = line.strip()
+		line = ""
+		while line == "":
+			line = sys.stdin.readline()
+			if not line:
+				raise EOFError()
+			line = line.strip()
 
 		if 'PING' in line:
 			print("PONG")


### PR DESCRIPTION
On debian stable (net-snmp 5.9.3), net-snmp makes snmp_passpersist crash on every "set" command.
It appears net-snmp sends an empty line after receiving the "DONE" message.
I solved this problem by making snmp_passpersist ignore all empty input lines.